### PR TITLE
Only add CompProperties_Styleable to defs without it

### DIFF
--- a/1.4/Mods/Rimefeller/Patches/GeneratorsRimefellerPatches.xml
+++ b/1.4/Mods/Rimefeller/Patches/GeneratorsRimefellerPatches.xml
@@ -2,75 +2,91 @@
 <Patch>
 	<Operation Class="PatchOperationConditional">
 		<success>Always</success>
-		<xpath>/Defs/ThingDef[defName = "OilWell"]/comps</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName = "OilWell"]</xpath>
-			<value>
-				<comps>
-					<li Class="CompProperties_Styleable"/>
-				</comps>
-			</value>
-		</nomatch>
-		<match Class="PatchOperationAdd">
+		<xpath>/Defs/ThingDef[defName = "OilWell"]/comps/li[@Class = "CompProperties_Styleable"]</xpath>
+		<nomatch Class="PatchOperationConditional">
+			<success>Always</success>
 			<xpath>/Defs/ThingDef[defName = "OilWell"]/comps</xpath>
-			<value>
-				<li Class="CompProperties_Styleable"/>
-			</value>
-		</match>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "OilWell"]</xpath>
+				<value>
+					<comps>
+						<li Class="CompProperties_Styleable"/>
+					</comps>
+				</value>
+			</nomatch>
+			<match Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "OilWell"]/comps</xpath>
+				<value>
+					<li Class="CompProperties_Styleable"/>
+				</value>
+			</match>
+		</nomatch>
 	</Operation>
 	<Operation Class="PatchOperationConditional">
 		<success>Always</success>
-		<xpath>/Defs/ThingDef[defName = "DeepOilWell"]/comps</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName = "DeepOilWell"]</xpath>
-			<value>
-				<comps>
-					<li Class="CompProperties_Styleable"/>
-				</comps>
-			</value>
-		</nomatch>
-		<match Class="PatchOperationAdd">
+		<xpath>/Defs/ThingDef[defName = "DeepOilWell"]/comps/li[@Class = "CompProperties_Styleable"]</xpath>
+		<nomatch Class="PatchOperationConditional">
+			<success>Always</success>
 			<xpath>/Defs/ThingDef[defName = "DeepOilWell"]/comps</xpath>
-			<value>
-				<li Class="CompProperties_Styleable"/>
-			</value>
-		</match>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "DeepOilWell"]</xpath>
+				<value>
+					<comps>
+						<li Class="CompProperties_Styleable"/>
+					</comps>
+				</value>
+			</nomatch>
+			<match Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "DeepOilWell"]/comps</xpath>
+				<value>
+					<li Class="CompProperties_Styleable"/>
+				</value>
+			</match>
+		</nomatch>
 	</Operation>
 	<Operation Class="PatchOperationConditional">
 		<success>Always</success>
-		<xpath>/Defs/ThingDef[defName = "OilStorage"]/comps</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName = "OilStorage"]</xpath>
-			<value>
-				<comps>
-					<li Class="CompProperties_Styleable"/>
-				</comps>
-			</value>
-		</nomatch>
-		<match Class="PatchOperationAdd">
+		<xpath>/Defs/ThingDef[defName = "OilStorage"]/comps/li[@Class = "CompProperties_Styleable"]</xpath>
+		<nomatch Class="PatchOperationConditional">
+			<success>Always</success>
 			<xpath>/Defs/ThingDef[defName = "OilStorage"]/comps</xpath>
-			<value>
-				<li Class="CompProperties_Styleable"/>
-			</value>
-		</match>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "OilStorage"]</xpath>
+				<value>
+					<comps>
+						<li Class="CompProperties_Styleable"/>
+					</comps>
+				</value>
+			</nomatch>
+			<match Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "OilStorage"]/comps</xpath>
+				<value>
+					<li Class="CompProperties_Styleable"/>
+				</value>
+			</match>
+		</nomatch>
 	</Operation>
 	<Operation Class="PatchOperationConditional">
 		<success>Always</success>
-		<xpath>/Defs/ThingDef[defName = "FuelStorage"]/comps</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName = "FuelStorage"]</xpath>
-			<value>
-				<comps>
-					<li Class="CompProperties_Styleable"/>
-				</comps>
-			</value>
-		</nomatch>
-		<match Class="PatchOperationAdd">
+		<xpath>/Defs/ThingDef[defName = "FuelStorage"]/comps/li[@Class = "CompProperties_Styleable"]</xpath>
+		<nomatch Class="PatchOperationConditional">
+			<success>Always</success>
 			<xpath>/Defs/ThingDef[defName = "FuelStorage"]/comps</xpath>
-			<value>
-				<li Class="CompProperties_Styleable"/>
-			</value>
-		</match>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "FuelStorage"]</xpath>
+				<value>
+					<comps>
+						<li Class="CompProperties_Styleable"/>
+					</comps>
+				</value>
+			</nomatch>
+			<match Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "FuelStorage"]/comps</xpath>
+				<value>
+					<li Class="CompProperties_Styleable"/>
+				</value>
+			</match>
+		</nomatch>
 	</Operation>
 	
 	

--- a/1.4/Mods/Royalty/Patches/ShipBeaconPatch.xml
+++ b/1.4/Mods/Royalty/Patches/ShipBeaconPatch.xml
@@ -6,21 +6,25 @@
 
 	<Operation Class="PatchOperationConditional">
 		<success>Always</success>
-		<xpath>/Defs/ThingDef[defName = "ShipLandingBeacon"]/comps</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName = "ShipLandingBeacon"]</xpath>
-			<value>
-				<comps>
-					<li Class="CompProperties_Styleable" />
-				</comps>
-			</value>
-		</nomatch>
-		<match Class="PatchOperationAdd">
+		<xpath>/Defs/ThingDef[defName = "ShipLandingBeacon"]/comps/li[@Class = "CompProperties_Styleable"]</xpath>
+		<nomatch Class="PatchOperationConditional">
+			<success>Always</success>
 			<xpath>/Defs/ThingDef[defName = "ShipLandingBeacon"]/comps</xpath>
-			<value>
-				<li Class="CompProperties_Styleable" />
-			</value>
-		</match>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "ShipLandingBeacon"]</xpath>
+				<value>
+					<comps>
+						<li Class="CompProperties_Styleable" />
+					</comps>
+				</value>
+			</nomatch>
+			<match Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "ShipLandingBeacon"]/comps</xpath>
+				<value>
+					<li Class="CompProperties_Styleable" />
+				</value>
+			</match>
+		</nomatch>
 	</Operation>
 
 

--- a/1.4/Mods/VanillaHelixienGas/Patches/GeneratorsVHGEPatches.xml
+++ b/1.4/Mods/VanillaHelixienGas/Patches/GeneratorsVHGEPatches.xml
@@ -2,203 +2,247 @@
 <Patch>
 	<Operation Class="PatchOperationConditional">
 		<success>Always</success>
-		<xpath>/Defs/ThingDef[defName = "VHGE_HelixienPipe"]/comps</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName = "VHGE_HelixienPipe"]</xpath>
-			<value>
-				<comps>
-					<li Class="CompProperties_Styleable"/>
-				</comps>
-			</value>
-		</nomatch>
-		<match Class="PatchOperationAdd">
+		<xpath>/Defs/ThingDef[defName = "VHGE_HelixienPipe"]/comps/li[@Class = "CompProperties_Styleable"]</xpath>
+		<nomatch Class="PatchOperationConditional">
+			<success>Always</success>
 			<xpath>/Defs/ThingDef[defName = "VHGE_HelixienPipe"]/comps</xpath>
-			<value>
-				<li Class="CompProperties_Styleable"/>
-			</value>
-		</match>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "VHGE_HelixienPipe"]</xpath>
+				<value>
+					<comps>
+						<li Class="CompProperties_Styleable"/>
+					</comps>
+				</value>
+			</nomatch>
+			<match Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "VHGE_HelixienPipe"]/comps</xpath>
+				<value>
+					<li Class="CompProperties_Styleable"/>
+				</value>
+			</match>
+		</nomatch>
 	</Operation>
 	<Operation Class="PatchOperationConditional">
 		<success>Always</success>
-		<xpath>/Defs/ThingDef[defName = "VHGE_GasTank"]/comps</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName = "VHGE_GasTank"]</xpath>
-			<value>
-				<comps>
-					<li Class="CompProperties_Styleable"/>
-				</comps>
-			</value>
-		</nomatch>
-		<match Class="PatchOperationAdd">
+		<xpath>/Defs/ThingDef[defName = "VHGE_GasTank"]/comps/li[@Class = "CompProperties_Styleable"]</xpath>
+		<nomatch Class="PatchOperationConditional">
+			<success>Always</success>
 			<xpath>/Defs/ThingDef[defName = "VHGE_GasTank"]/comps</xpath>
-			<value>
-				<li Class="CompProperties_Styleable"/>
-			</value>
-		</match>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "VHGE_GasTank"]</xpath>
+				<value>
+					<comps>
+						<li Class="CompProperties_Styleable"/>
+					</comps>
+				</value>
+			</nomatch>
+			<match Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "VHGE_GasTank"]/comps</xpath>
+				<value>
+					<li Class="CompProperties_Styleable"/>
+				</value>
+			</match>
+		</nomatch>
 	</Operation>
 	<Operation Class="PatchOperationConditional">
 		<success>Always</success>
-		<xpath>/Defs/ThingDef[defName = "VHGE_HelixienPump"]/comps</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName = "VHGE_HelixienPump"]</xpath>
-			<value>
-				<comps>
-					<li Class="CompProperties_Styleable"/>
-				</comps>
-			</value>
-		</nomatch>
-		<match Class="PatchOperationAdd">
+		<xpath>/Defs/ThingDef[defName = "VHGE_HelixienPump"]/comps/li[@Class = "CompProperties_Styleable"]</xpath>
+		<nomatch Class="PatchOperationConditional">
+			<success>Always</success>
 			<xpath>/Defs/ThingDef[defName = "VHGE_HelixienPump"]/comps</xpath>
-			<value>
-				<li Class="CompProperties_Styleable"/>
-			</value>
-		</match>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "VHGE_HelixienPump"]</xpath>
+				<value>
+					<comps>
+						<li Class="CompProperties_Styleable"/>
+					</comps>
+				</value>
+			</nomatch>
+			<match Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "VHGE_HelixienPump"]/comps</xpath>
+				<value>
+					<li Class="CompProperties_Styleable"/>
+				</value>
+			</match>
+		</nomatch>
 	</Operation>
 	<Operation Class="PatchOperationConditional">
 		<success>Always</success>
-		<xpath>/Defs/ThingDef[defName = "VHGE_HelixienGenerator"]/comps</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName = "VHGE_HelixienGenerator"]</xpath>
-			<value>
-				<comps>
-					<li Class="CompProperties_Styleable"/>
-				</comps>
-			</value>
-		</nomatch>
-		<match Class="PatchOperationAdd">
+		<xpath>/Defs/ThingDef[defName = "VHGE_HelixienGenerator"]/comps/li[@Class = "CompProperties_Styleable"]</xpath>
+		<nomatch Class="PatchOperationConditional">
+			<success>Always</success>
 			<xpath>/Defs/ThingDef[defName = "VHGE_HelixienGenerator"]/comps</xpath>
-			<value>
-				<li Class="CompProperties_Styleable"/>
-			</value>
-		</match>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "VHGE_HelixienGenerator"]</xpath>
+				<value>
+					<comps>
+						<li Class="CompProperties_Styleable"/>
+					</comps>
+				</value>
+			</nomatch>
+			<match Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "VHGE_HelixienGenerator"]/comps</xpath>
+				<value>
+					<li Class="CompProperties_Styleable"/>
+				</value>
+			</match>
+		</nomatch>
 	</Operation>
-	
+
 	<Operation Class="PatchOperationConditional">
 		<success>Always</success>
-		<xpath>/Defs/ThingDef[defName = "VHGE_GasPoweredStove"]/comps</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName = "VHGE_GasPoweredStove"]</xpath>
-			<value>
-				<comps>
-					<li Class="CompProperties_Styleable"/>
-				</comps>
-			</value>
-		</nomatch>
-		<match Class="PatchOperationAdd">
+		<xpath>/Defs/ThingDef[defName = "VHGE_GasPoweredStove"]/comps/li[@Class = "CompProperties_Styleable"]</xpath>
+		<nomatch Class="PatchOperationConditional">
+			<success>Always</success>
 			<xpath>/Defs/ThingDef[defName = "VHGE_GasPoweredStove"]/comps</xpath>
-			<value>
-				<li Class="CompProperties_Styleable"/>
-			</value>
-		</match>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "VHGE_GasPoweredStove"]</xpath>
+				<value>
+					<comps>
+						<li Class="CompProperties_Styleable"/>
+					</comps>
+				</value>
+			</nomatch>
+			<match Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "VHGE_GasPoweredStove"]/comps</xpath>
+				<value>
+					<li Class="CompProperties_Styleable"/>
+				</value>
+			</match>
+		</nomatch>
 	</Operation>
 	<Operation Class="PatchOperationConditional">
 		<success>Always</success>
-		<xpath>/Defs/ThingDef[defName = "VHGE_GasPoweredSmelter"]/comps</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName = "VHGE_GasPoweredSmelter"]</xpath>
-			<value>
-				<comps>
-					<li Class="CompProperties_Styleable"/>
-				</comps>
-			</value>
-		</nomatch>
-		<match Class="PatchOperationAdd">
+		<xpath>/Defs/ThingDef[defName = "VHGE_GasPoweredSmelter"]/comps/li[@Class = "CompProperties_Styleable"]</xpath>
+		<nomatch Class="PatchOperationConditional">
+			<success>Always</success>
 			<xpath>/Defs/ThingDef[defName = "VHGE_GasPoweredSmelter"]/comps</xpath>
-			<value>
-				<li Class="CompProperties_Styleable"/>
-			</value>
-		</match>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "VHGE_GasPoweredSmelter"]</xpath>
+				<value>
+					<comps>
+						<li Class="CompProperties_Styleable"/>
+					</comps>
+				</value>
+			</nomatch>
+			<match Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "VHGE_GasPoweredSmelter"]/comps</xpath>
+				<value>
+					<li Class="CompProperties_Styleable"/>
+				</value>
+			</match>
+		</nomatch>
 	</Operation>
 	<Operation Class="PatchOperationConditional">
 		<success>Always</success>
-		<xpath>/Defs/ThingDef[defName = "VHGE_GasPoweredCrematorium"]/comps</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName = "VHGE_GasPoweredCrematorium"]</xpath>
-			<value>
-				<comps>
-					<li Class="CompProperties_Styleable"/>
-				</comps>
-			</value>
-		</nomatch>
-		<match Class="PatchOperationAdd">
+		<xpath>/Defs/ThingDef[defName = "VHGE_GasPoweredCrematorium"]/comps/li[@Class = "CompProperties_Styleable"]</xpath>
+		<nomatch Class="PatchOperationConditional">
+			<success>Always</success>
 			<xpath>/Defs/ThingDef[defName = "VHGE_GasPoweredCrematorium"]/comps</xpath>
-			<value>
-				<li Class="CompProperties_Styleable"/>
-			</value>
-		</match>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "VHGE_GasPoweredCrematorium"]</xpath>
+				<value>
+					<comps>
+						<li Class="CompProperties_Styleable"/>
+					</comps>
+				</value>
+			</nomatch>
+			<match Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "VHGE_GasPoweredCrematorium"]/comps</xpath>
+				<value>
+					<li Class="CompProperties_Styleable"/>
+				</value>
+			</match>
+		</nomatch>
 	</Operation>
-	
+
 	<Operation Class="PatchOperationConditional">
 		<success>Always</success>
-		<xpath>/Defs/ThingDef[defName = "VHGE_GasCooler"]/comps</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName = "VHGE_GasCooler"]</xpath>
-			<value>
-				<comps>
-					<li Class="CompProperties_Styleable"/>
-				</comps>
-			</value>
-		</nomatch>
-		<match Class="PatchOperationAdd">
+		<xpath>/Defs/ThingDef[defName = "VHGE_GasCooler"]/comps/li[@Class = "CompProperties_Styleable"]</xpath>
+		<nomatch Class="PatchOperationConditional">
+			<success>Always</success>
 			<xpath>/Defs/ThingDef[defName = "VHGE_GasCooler"]/comps</xpath>
-			<value>
-				<li Class="CompProperties_Styleable"/>
-			</value>
-		</match>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "VHGE_GasCooler"]</xpath>
+				<value>
+					<comps>
+						<li Class="CompProperties_Styleable"/>
+					</comps>
+				</value>
+			</nomatch>
+			<match Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "VHGE_GasCooler"]/comps</xpath>
+				<value>
+					<li Class="CompProperties_Styleable"/>
+				</value>
+			</match>
+		</nomatch>
 	</Operation>
 	<Operation Class="PatchOperationConditional">
 		<success>Always</success>
-		<xpath>/Defs/ThingDef[defName = "VHGE_GasHeater"]/comps</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName = "VHGE_GasHeater"]</xpath>
-			<value>
-				<comps>
-					<li Class="CompProperties_Styleable"/>
-				</comps>
-			</value>
-		</nomatch>
-		<match Class="PatchOperationAdd">
+		<xpath>/Defs/ThingDef[defName = "VHGE_GasHeater"]/comps/li[@Class = "CompProperties_Styleable"]</xpath>
+		<nomatch Class="PatchOperationConditional">
+			<success>Always</success>
 			<xpath>/Defs/ThingDef[defName = "VHGE_GasHeater"]/comps</xpath>
-			<value>
-				<li Class="CompProperties_Styleable"/>
-			</value>
-		</match>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "VHGE_GasHeater"]</xpath>
+				<value>
+					<comps>
+						<li Class="CompProperties_Styleable"/>
+					</comps>
+				</value>
+			</nomatch>
+			<match Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "VHGE_GasHeater"]/comps</xpath>
+				<value>
+					<li Class="CompProperties_Styleable"/>
+				</value>
+			</match>
+		</nomatch>
 	</Operation>
 	<Operation Class="PatchOperationConditional">
 		<success>Always</success>
-		<xpath>/Defs/ThingDef[defName = "VHGE_GasSunLamp"]/comps</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName = "VHGE_GasSunLamp"]</xpath>
-			<value>
-				<comps>
-					<li Class="CompProperties_Styleable"/>
-				</comps>
-			</value>
-		</nomatch>
-		<match Class="PatchOperationAdd">
+		<xpath>/Defs/ThingDef[defName = "VHGE_GasSunLamp"]/comps/li[@Class = "CompProperties_Styleable"]</xpath>
+		<nomatch Class="PatchOperationConditional">
+			<success>Always</success>
 			<xpath>/Defs/ThingDef[defName = "VHGE_GasSunLamp"]/comps</xpath>
-			<value>
-				<li Class="CompProperties_Styleable"/>
-			</value>
-		</match>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "VHGE_GasSunLamp"]</xpath>
+				<value>
+					<comps>
+						<li Class="CompProperties_Styleable"/>
+					</comps>
+				</value>
+			</nomatch>
+			<match Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "VHGE_GasSunLamp"]/comps</xpath>
+				<value>
+					<li Class="CompProperties_Styleable"/>
+				</value>
+			</match>
+		</nomatch>
 	</Operation>
 	<Operation Class="PatchOperationConditional">
 		<success>Always</success>
-		<xpath>/Defs/ThingDef[defName = "VHGE_GasWallLight"]/comps</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName = "VHGE_GasWallLight"]</xpath>
-			<value>
-				<comps>
-					<li Class="CompProperties_Styleable"/>
-				</comps>
-			</value>
-		</nomatch>
-		<match Class="PatchOperationAdd">
+		<xpath>/Defs/ThingDef[defName = "VHGE_GasWallLight"]/comps/li[@Class = "CompProperties_Styleable"]</xpath>
+		<nomatch Class="PatchOperationConditional">
+			<success>Always</success>
 			<xpath>/Defs/ThingDef[defName = "VHGE_GasWallLight"]/comps</xpath>
-			<value>
-				<li Class="CompProperties_Styleable"/>
-			</value>
-		</match>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "VHGE_GasWallLight"]</xpath>
+				<value>
+					<comps>
+						<li Class="CompProperties_Styleable"/>
+					</comps>
+				</value>
+			</nomatch>
+			<match Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "VHGE_GasWallLight"]/comps</xpath>
+				<value>
+					<li Class="CompProperties_Styleable"/>
+				</value>
+			</match>
+		</nomatch>
 	</Operation>
 	
 </Patch>

--- a/1.4/Mods/VanillaPowerExpanded/Patches/GeneratorsVPEPatches.xml
+++ b/1.4/Mods/VanillaPowerExpanded/Patches/GeneratorsVPEPatches.xml
@@ -2,167 +2,203 @@
 <Patch>
 	<Operation Class="PatchOperationConditional">
 		<success>Always</success>
-		<xpath>/Defs/ThingDef[defName = "VPE_NuclearGenerator"]/comps</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName = "VPE_NuclearGenerator"]</xpath>
-			<value>
-				<comps>
-					<li Class="CompProperties_Styleable"/>
-				</comps>
-			</value>
-		</nomatch>
-		<match Class="PatchOperationAdd">
+		<xpath>/Defs/ThingDef[defName = "VPE_NuclearGenerator"]/comps/li[@Class = "CompProperties_Styleable"]</xpath>
+		<nomatch Class="PatchOperationConditional">
+			<success>Always</success>
 			<xpath>/Defs/ThingDef[defName = "VPE_NuclearGenerator"]/comps</xpath>
-			<value>
-				<li Class="CompProperties_Styleable"/>
-			</value>
-		</match>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "VPE_NuclearGenerator"]</xpath>
+				<value>
+					<comps>
+						<li Class="CompProperties_Styleable"/>
+					</comps>
+				</value>
+			</nomatch>
+			<match Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "VPE_NuclearGenerator"]/comps</xpath>
+				<value>
+					<li Class="CompProperties_Styleable"/>
+				</value>
+			</match>
+		</nomatch>
 	</Operation>
 	<Operation Class="PatchOperationConditional">
 		<success>Always</success>
-		<xpath>/Defs/ThingDef[defName = "VFE_AdvancedSolarGenerator"]/comps</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName = "VFE_AdvancedSolarGenerator"]</xpath>
-			<value>
-				<comps>
-					<li Class="CompProperties_Styleable"/>
-				</comps>
-			</value>
-		</nomatch>
-		<match Class="PatchOperationAdd">
+		<xpath>/Defs/ThingDef[defName = "VFE_AdvancedSolarGenerator"]/comps/li[@Class = "CompProperties_Styleable"]</xpath>
+		<nomatch Class="PatchOperationConditional">
+			<success>Always</success>
 			<xpath>/Defs/ThingDef[defName = "VFE_AdvancedSolarGenerator"]/comps</xpath>
-			<value>
-				<li Class="CompProperties_Styleable"/>
-			</value>
-		</match>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "VFE_AdvancedSolarGenerator"]</xpath>
+				<value>
+					<comps>
+						<li Class="CompProperties_Styleable"/>
+					</comps>
+				</value>
+			</nomatch>
+			<match Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "VFE_AdvancedSolarGenerator"]/comps</xpath>
+				<value>
+					<li Class="CompProperties_Styleable"/>
+				</value>
+			</match>
+		</nomatch>
 	</Operation>
 	<Operation Class="PatchOperationConditional">
 		<success>Always</success>
-		<xpath>/Defs/ThingDef[defName = "VFE_AdvancedWindTurbine"]/comps</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName = "VFE_AdvancedWindTurbine"]</xpath>
-			<value>
-				<comps>
-					<li Class="CompProperties_Styleable"/>
-				</comps>
-			</value>
-		</nomatch>
-		<match Class="PatchOperationAdd">
+		<xpath>/Defs/ThingDef[defName = "VFE_AdvancedWindTurbine"]/comps/li[@Class = "CompProperties_Styleable"]</xpath>
+		<nomatch Class="PatchOperationConditional">
+			<success>Always</success>
 			<xpath>/Defs/ThingDef[defName = "VFE_AdvancedWindTurbine"]/comps</xpath>
-			<value>
-				<li Class="CompProperties_Styleable"/>
-			</value>
-		</match>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "VFE_AdvancedWindTurbine"]</xpath>
+				<value>
+					<comps>
+						<li Class="CompProperties_Styleable"/>
+					</comps>
+				</value>
+			</nomatch>
+			<match Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "VFE_AdvancedWindTurbine"]/comps</xpath>
+				<value>
+					<li Class="CompProperties_Styleable"/>
+				</value>
+			</match>
+		</nomatch>
 	</Operation>
 	
 	<Operation Class="PatchOperationConditional">
 		<success>Always</success>
-		<xpath>/Defs/ThingDef[defName = "VFE_LargeBattery"]/comps</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName = "VFE_LargeBattery"]</xpath>
-			<value>
-				<comps>
-					<li Class="CompProperties_Styleable"/>
-				</comps>
-			</value>
-		</nomatch>
-		<match Class="PatchOperationAdd">
+		<xpath>/Defs/ThingDef[defName = "VFE_LargeBattery"]/comps/li[@Class = "CompProperties_Styleable"]</xpath>
+		<nomatch Class="PatchOperationConditional">
+			<success>Always</success>
 			<xpath>/Defs/ThingDef[defName = "VFE_LargeBattery"]/comps</xpath>
-			<value>
-				<li Class="CompProperties_Styleable"/>
-			</value>
-		</match>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "VFE_LargeBattery"]</xpath>
+				<value>
+					<comps>
+						<li Class="CompProperties_Styleable"/>
+					</comps>
+				</value>
+			</nomatch>
+			<match Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "VFE_LargeBattery"]/comps</xpath>
+				<value>
+					<li Class="CompProperties_Styleable"/>
+				</value>
+			</match>
+		</nomatch>
 	</Operation>
 	<Operation Class="PatchOperationConditional">
 		<success>Always</success>
-		<xpath>/Defs/ThingDef[defName = "VFE_LargeAdvancedBattery"]/comps</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName = "VFE_LargeAdvancedBattery"]</xpath>
-			<value>
-				<comps>
-					<li Class="CompProperties_Styleable"/>
-				</comps>
-			</value>
-		</nomatch>
-		<match Class="PatchOperationAdd">
+		<xpath>/Defs/ThingDef[defName = "VFE_LargeAdvancedBattery"]/comps/li[@Class = "CompProperties_Styleable"]</xpath>
+		<nomatch Class="PatchOperationConditional">
+			<success>Always</success>
 			<xpath>/Defs/ThingDef[defName = "VFE_LargeAdvancedBattery"]/comps</xpath>
-			<value>
-				<li Class="CompProperties_Styleable"/>
-			</value>
-		</match>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "VFE_LargeAdvancedBattery"]</xpath>
+				<value>
+					<comps>
+						<li Class="CompProperties_Styleable"/>
+					</comps>
+				</value>
+			</nomatch>
+			<match Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "VFE_LargeAdvancedBattery"]/comps</xpath>
+				<value>
+					<li Class="CompProperties_Styleable"/>
+				</value>
+			</match>
+		</nomatch>
 	</Operation>
 	<Operation Class="PatchOperationConditional">
 		<success>Always</success>
-		<xpath>/Defs/ThingDef[defName = "VFE_SmallBattery"]/comps</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName = "VFE_SmallBattery"]</xpath>
-			<value>
-				<comps>
-					<li Class="CompProperties_Styleable"/>
-				</comps>
-			</value>
-		</nomatch>
-		<match Class="PatchOperationAdd">
+		<xpath>/Defs/ThingDef[defName = "VFE_SmallBattery"]/comps/li[@Class = "CompProperties_Styleable"]</xpath>
+		<nomatch Class="PatchOperationConditional">
+			<success>Always</success>
 			<xpath>/Defs/ThingDef[defName = "VFE_SmallBattery"]/comps</xpath>
-			<value>
-				<li Class="CompProperties_Styleable"/>
-			</value>
-		</match>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "VFE_SmallBattery"]</xpath>
+				<value>
+					<comps>
+						<li Class="CompProperties_Styleable"/>
+					</comps>
+				</value>
+			</nomatch>
+			<match Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "VFE_SmallBattery"]/comps</xpath>
+				<value>
+					<li Class="CompProperties_Styleable"/>
+				</value>
+			</match>
+		</nomatch>
 	</Operation>
 	<Operation Class="PatchOperationConditional">
 		<success>Always</success>
-		<xpath>/Defs/ThingDef[defName = "VFE_AdvancedBattery"]/comps</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName = "VFE_AdvancedBattery"]</xpath>
-			<value>
-				<comps>
-					<li Class="CompProperties_Styleable"/>
-				</comps>
-			</value>
-		</nomatch>
-		<match Class="PatchOperationAdd">
+		<xpath>/Defs/ThingDef[defName = "VFE_AdvancedBattery"]/comps/li[@Class = "CompProperties_Styleable"]</xpath>
+		<nomatch Class="PatchOperationConditional">
+			<success>Always</success>
 			<xpath>/Defs/ThingDef[defName = "VFE_AdvancedBattery"]/comps</xpath>
-			<value>
-				<li Class="CompProperties_Styleable"/>
-			</value>
-		</match>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "VFE_AdvancedBattery"]</xpath>
+				<value>
+					<comps>
+						<li Class="CompProperties_Styleable"/>
+					</comps>
+				</value>
+			</nomatch>
+			<match Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "VFE_AdvancedBattery"]/comps</xpath>
+				<value>
+					<li Class="CompProperties_Styleable"/>
+				</value>
+			</match>
+		</nomatch>
 	</Operation>
 	
 	<Operation Class="PatchOperationConditional">
 		<success>Always</success>
-		<xpath>/Defs/ThingDef[defName = "VFE_AdvancedWatermillGenerator"]/comps</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName = "VFE_AdvancedWatermillGenerator"]</xpath>
-			<value>
-				<comps>
-					<li Class="CompProperties_Styleable"/>
-				</comps>
-			</value>
-		</nomatch>
-		<match Class="PatchOperationAdd">
+		<xpath>/Defs/ThingDef[defName = "VFE_AdvancedWatermillGenerator"]/comps/li[@Class = "CompProperties_Styleable"]</xpath>
+		<nomatch Class="PatchOperationConditional">
+			<success>Always</success>
 			<xpath>/Defs/ThingDef[defName = "VFE_AdvancedWatermillGenerator"]/comps</xpath>
-			<value>
-				<li Class="CompProperties_Styleable"/>
-			</value>
-		</match>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "VFE_AdvancedWatermillGenerator"]</xpath>
+				<value>
+					<comps>
+						<li Class="CompProperties_Styleable"/>
+					</comps>
+				</value>
+			</nomatch>
+			<match Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "VFE_AdvancedWatermillGenerator"]/comps</xpath>
+				<value>
+					<li Class="CompProperties_Styleable"/>
+				</value>
+			</match>
+		</nomatch>
 	</Operation>
 	<Operation Class="PatchOperationConditional">
 		<success>Always</success>
-		<xpath>/Defs/ThingDef[defName = "VFE_TidalGenerator"]/comps</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName = "VFE_TidalGenerator"]</xpath>
-			<value>
-				<comps>
-					<li Class="CompProperties_Styleable"/>
-				</comps>
-			</value>
-		</nomatch>
-		<match Class="PatchOperationAdd">
+		<xpath>/Defs/ThingDef[defName = "VFE_TidalGenerator"]/comps/li[@Class = "CompProperties_Styleable"]</xpath>
+		<nomatch Class="PatchOperationConditional">
+			<success>Always</success>
 			<xpath>/Defs/ThingDef[defName = "VFE_TidalGenerator"]/comps</xpath>
-			<value>
-				<li Class="CompProperties_Styleable"/>
-			</value>
-		</match>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "VFE_TidalGenerator"]</xpath>
+				<value>
+					<comps>
+						<li Class="CompProperties_Styleable"/>
+					</comps>
+				</value>
+			</nomatch>
+			<match Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "VFE_TidalGenerator"]/comps</xpath>
+				<value>
+					<li Class="CompProperties_Styleable"/>
+				</value>
+			</match>
+		</nomatch>
 	</Operation>
 	
 	

--- a/1.4/Mods/WallUtilities/Patches/WallUtilitiesPatches.xml
+++ b/1.4/Mods/WallUtilities/Patches/WallUtilitiesPatches.xml
@@ -2,40 +2,48 @@
 <Patch>
 	<Operation Class="PatchOperationConditional">
 		<success>Always</success>
-		<xpath>/Defs/ThingDef[defName = "Owl_Heater"]/comps</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName = "Owl_Heater"]</xpath>
-			<value>
-				<comps>
-					<li Class="CompProperties_Styleable"/>
-				</comps>
-			</value>
-		</nomatch>
-		<match Class="PatchOperationAdd">
+		<xpath>/Defs/ThingDef[defName = "Owl_Heater"]/comps/li[@Class = "CompProperties_Styleable"]</xpath>
+		<nomatch Class="PatchOperationConditional">
+			<success>Always</success>
 			<xpath>/Defs/ThingDef[defName = "Owl_Heater"]/comps</xpath>
-			<value>
-				<li Class="CompProperties_Styleable"/>
-			</value>
-		</match>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "Owl_Heater"]</xpath>
+				<value>
+					<comps>
+						<li Class="CompProperties_Styleable"/>
+					</comps>
+				</value>
+			</nomatch>
+			<match Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "Owl_Heater"]/comps</xpath>
+				<value>
+					<li Class="CompProperties_Styleable"/>
+				</value>
+			</match>
+		</nomatch>
 	</Operation>
 	
 	<Operation Class="PatchOperationConditional">
 		<success>Always</success>
-		<xpath>/Defs/ThingDef[defName = "Vent"]/comps</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName = "Vent"]</xpath>
-			<value>
-				<comps>
-					<li Class="CompProperties_Styleable"/>
-				</comps>
-			</value>
-		</nomatch>
-		<match Class="PatchOperationAdd">
+		<xpath>/Defs/ThingDef[defName = "Vent"]/comps/li[@Class = "CompProperties_Styleable"]</xpath>
+		<nomatch Class="PatchOperationConditional">
+			<success>Always</success>
 			<xpath>/Defs/ThingDef[defName = "Vent"]/comps</xpath>
-			<value>
-				<li Class="CompProperties_Styleable"/>
-			</value>
-		</match>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "Vent"]</xpath>
+				<value>
+					<comps>
+						<li Class="CompProperties_Styleable"/>
+					</comps>
+				</value>
+			</nomatch>
+			<match Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "Vent"]/comps</xpath>
+				<value>
+					<li Class="CompProperties_Styleable"/>
+				</value>
+			</match>
+		</nomatch>
 	</Operation>
 	
 	

--- a/1.4/Patches/MakingFurnitureStyleable/ComponentsPatch.xml
+++ b/1.4/Patches/MakingFurnitureStyleable/ComponentsPatch.xml
@@ -6,21 +6,25 @@
 
 	<Operation Class="PatchOperationConditional">
 		<success>Always</success>
-		<xpath>/Defs/ThingDef[defName = "ComponentIndustrial"]/comps</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName = "ComponentIndustrial"]</xpath>
-			<value>
-				<comps>
-					<li Class="CompProperties_Styleable" />
-				</comps>
-			</value>
-		</nomatch>
-		<match Class="PatchOperationAdd">
+		<xpath>/Defs/ThingDef[defName = "ComponentIndustrial"]/comps/li[@Class = "CompProperties_Styleable"]</xpath>
+		<nomatch Class="PatchOperationConditional">
+			<success>Always</success>
 			<xpath>/Defs/ThingDef[defName = "ComponentIndustrial"]/comps</xpath>
-			<value>
-				<li Class="CompProperties_Styleable" />
-			</value>
-		</match>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "ComponentIndustrial"]</xpath>
+				<value>
+					<comps>
+						<li Class="CompProperties_Styleable" />
+					</comps>
+				</value>
+			</nomatch>
+			<match Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "ComponentIndustrial"]/comps</xpath>
+				<value>
+					<li Class="CompProperties_Styleable" />
+				</value>
+			</match>
+		</nomatch>
 	</Operation>
 
 

--- a/1.4/Patches/MakingFurnitureStyleable/CoolerPatch.xml
+++ b/1.4/Patches/MakingFurnitureStyleable/CoolerPatch.xml
@@ -6,21 +6,25 @@
 
 	<Operation Class="PatchOperationConditional">
 		<success>Always</success>
-		<xpath>/Defs/ThingDef[defName = "Cooler"]/comps</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName = "Cooler"]</xpath>
-			<value>
-				<comps>
-					<li Class="CompProperties_Styleable"/>
-				</comps>
-			</value>
-		</nomatch>
-		<match Class="PatchOperationAdd">
+		<xpath>/Defs/ThingDef[defName = "Cooler"]/comps/li[@Class = "CompProperties_Styleable"]</xpath>
+		<nomatch Class="PatchOperationConditional">
+			<success>Always</success>
 			<xpath>/Defs/ThingDef[defName = "Cooler"]/comps</xpath>
-			<value>
-				<li Class="CompProperties_Styleable"/>
-			</value>
-		</match>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "Cooler"]</xpath>
+				<value>
+					<comps>
+						<li Class="CompProperties_Styleable"/>
+					</comps>
+				</value>
+			</nomatch>
+			<match Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "Cooler"]/comps</xpath>
+				<value>
+					<li Class="CompProperties_Styleable"/>
+				</value>
+			</match>
+		</nomatch>
 	</Operation>
 
 

--- a/1.4/Patches/MakingFurnitureStyleable/DeepDrillPatch.xml
+++ b/1.4/Patches/MakingFurnitureStyleable/DeepDrillPatch.xml
@@ -6,21 +6,25 @@
 
 	<Operation Class="PatchOperationConditional">
 		<success>Always</success>
-		<xpath>/Defs/ThingDef[defName = "DeepDrill"]/comps</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName = "DeepDrill"]</xpath>
-			<value>
-				<comps>
-					<li Class="CompProperties_Styleable" />
-				</comps>
-			</value>
-		</nomatch>
-		<match Class="PatchOperationAdd">
+		<xpath>/Defs/ThingDef[defName = "DeepDrill"]/comps/li[@Class = "CompProperties_Styleable"]</xpath>
+		<nomatch Class="PatchOperationConditional">
+			<success>Always</success>
 			<xpath>/Defs/ThingDef[defName = "DeepDrill"]/comps</xpath>
-			<value>
-				<li Class="CompProperties_Styleable" />
-			</value>
-		</match>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "DeepDrill"]</xpath>
+				<value>
+					<comps>
+						<li Class="CompProperties_Styleable" />
+					</comps>
+				</value>
+			</nomatch>
+			<match Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "DeepDrill"]/comps</xpath>
+				<value>
+					<li Class="CompProperties_Styleable" />
+				</value>
+			</match>
+		</nomatch>
 	</Operation>
 
 

--- a/1.4/Patches/MakingFurnitureStyleable/GeneratorsPatch.xml
+++ b/1.4/Patches/MakingFurnitureStyleable/GeneratorsPatch.xml
@@ -6,78 +6,94 @@
 
 	<Operation Class="PatchOperationConditional">
 		<success>Always</success>
-		<xpath>/Defs/ThingDef[defName = "WoodFiredGenerator"]/comps</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName = "WoodFiredGenerator"]</xpath>
-			<value>
-				<comps>
-					<li Class="CompProperties_Styleable" />
-				</comps>
-			</value>
-		</nomatch>
-		<match Class="PatchOperationAdd">
+		<xpath>/Defs/ThingDef[defName = "WoodFiredGenerator"]/comps/li[@Class = "CompProperties_Styleable"]</xpath>
+		<nomatch Class="PatchOperationConditional">
+			<success>Always</success>
 			<xpath>/Defs/ThingDef[defName = "WoodFiredGenerator"]/comps</xpath>
-			<value>
-				<li Class="CompProperties_Styleable" />
-			</value>
-		</match>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "WoodFiredGenerator"]</xpath>
+				<value>
+					<comps>
+						<li Class="CompProperties_Styleable" />
+					</comps>
+				</value>
+			</nomatch>
+			<match Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "WoodFiredGenerator"]/comps</xpath>
+				<value>
+					<li Class="CompProperties_Styleable" />
+				</value>
+			</match>
+		</nomatch>
 	</Operation>
 
 	<Operation Class="PatchOperationConditional">
 		<success>Always</success>
-		<xpath>/Defs/ThingDef[defName = "ChemfuelPoweredGenerator"]/comps</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName = "ChemfuelPoweredGenerator"]</xpath>
-			<value>
-				<comps>
-					<li Class="CompProperties_Styleable" />
-				</comps>
-			</value>
-		</nomatch>
-		<match Class="PatchOperationAdd">
+		<xpath>/Defs/ThingDef[defName = "ChemfuelPoweredGenerator"]/comps/li[@Class = "CompProperties_Styleable"]</xpath>
+		<nomatch Class="PatchOperationConditional">
+			<success>Always</success>
 			<xpath>/Defs/ThingDef[defName = "ChemfuelPoweredGenerator"]/comps</xpath>
-			<value>
-				<li Class="CompProperties_Styleable" />
-			</value>
-		</match>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "ChemfuelPoweredGenerator"]</xpath>
+				<value>
+					<comps>
+						<li Class="CompProperties_Styleable" />
+					</comps>
+				</value>
+			</nomatch>
+			<match Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "ChemfuelPoweredGenerator"]/comps</xpath>
+				<value>
+					<li Class="CompProperties_Styleable" />
+				</value>
+			</match>
+		</nomatch>
 	</Operation>
 	
 	<Operation Class="PatchOperationConditional">
 		<success>Always</success>
-		<xpath>/Defs/ThingDef[defName = "SolarGenerator"]/comps</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName = "SolarGenerator"]</xpath>
-			<value>
-				<comps>
-					<li Class="CompProperties_Styleable" />
-				</comps>
-			</value>
-		</nomatch>
-		<match Class="PatchOperationAdd">
+		<xpath>/Defs/ThingDef[defName = "SolarGenerator"]/comps/li[@Class = "CompProperties_Styleable"]</xpath>
+		<nomatch Class="PatchOperationConditional">
+			<success>Always</success>
 			<xpath>/Defs/ThingDef[defName = "SolarGenerator"]/comps</xpath>
-			<value>
-				<li Class="CompProperties_Styleable" />
-			</value>
-		</match>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "SolarGenerator"]</xpath>
+				<value>
+					<comps>
+						<li Class="CompProperties_Styleable" />
+					</comps>
+				</value>
+			</nomatch>
+			<match Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "SolarGenerator"]/comps</xpath>
+				<value>
+					<li Class="CompProperties_Styleable" />
+				</value>
+			</match>
+		</nomatch>
 	</Operation>
 	
 	<Operation Class="PatchOperationConditional">
 		<success>Always</success>
-		<xpath>/Defs/ThingDef[defName = "GeothermalGenerator"]/comps</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName = "GeothermalGenerator"]</xpath>
-			<value>
-				<comps>
-					<li Class="CompProperties_Styleable" />
-				</comps>
-			</value>
-		</nomatch>
-		<match Class="PatchOperationAdd">
+		<xpath>/Defs/ThingDef[defName = "GeothermalGenerator"]/comps/li[@Class = "CompProperties_Styleable"]</xpath>
+		<nomatch Class="PatchOperationConditional">
+			<success>Always</success>
 			<xpath>/Defs/ThingDef[defName = "GeothermalGenerator"]/comps</xpath>
-			<value>
-				<li Class="CompProperties_Styleable" />
-			</value>
-		</match>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "GeothermalGenerator"]</xpath>
+				<value>
+					<comps>
+						<li Class="CompProperties_Styleable" />
+					</comps>
+				</value>
+			</nomatch>
+			<match Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "GeothermalGenerator"]/comps</xpath>
+				<value>
+					<li Class="CompProperties_Styleable" />
+				</value>
+			</match>
+		</nomatch>
 	</Operation>
 
 

--- a/1.4/Patches/MakingFurnitureStyleable/NutrientMealsPatch.xml
+++ b/1.4/Patches/MakingFurnitureStyleable/NutrientMealsPatch.xml
@@ -6,21 +6,25 @@
 
 	<Operation Class="PatchOperationConditional">
 		<success>Always</success>
-		<xpath>/Defs/ThingDef[defName = "MealNutrientPaste"]/comps</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName = "MealNutrientPaste"]</xpath>
-			<value>
-				<comps>
-					<li Class="CompProperties_Styleable" />
-				</comps>
-			</value>
-		</nomatch>
-		<match Class="PatchOperationAdd">
+		<xpath>/Defs/ThingDef[defName = "MealNutrientPaste"]/comps/li[@Class = "CompProperties_Styleable"]</xpath>
+		<nomatch Class="PatchOperationConditional">
+			<success>Always</success>
 			<xpath>/Defs/ThingDef[defName = "MealNutrientPaste"]/comps</xpath>
-			<value>
-				<li Class="CompProperties_Styleable" />
-			</value>
-		</match>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "MealNutrientPaste"]</xpath>
+				<value>
+					<comps>
+						<li Class="CompProperties_Styleable" />
+					</comps>
+				</value>
+			</nomatch>
+			<match Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "MealNutrientPaste"]/comps</xpath>
+				<value>
+					<li Class="CompProperties_Styleable" />
+				</value>
+			</match>
+		</nomatch>
 	</Operation>
 
 

--- a/1.4/Patches/MakingFurnitureStyleable/TelescopePatch.xml
+++ b/1.4/Patches/MakingFurnitureStyleable/TelescopePatch.xml
@@ -6,21 +6,25 @@
 
 	<Operation Class="PatchOperationConditional">
 		<success>Always</success>
-		<xpath>/Defs/ThingDef[defName = "Telescope"]/comps</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName = "Telescope"]</xpath>
-			<value>
-				<comps>
-					<li Class="CompProperties_Styleable" />
-				</comps>
-			</value>
-		</nomatch>
-		<match Class="PatchOperationAdd">
+		<xpath>/Defs/ThingDef[defName = "Telescope"]/comps/li[@Class = "CompProperties_Styleable"]</xpath>
+		<nomatch Class="PatchOperationConditional">
+			<success>Always</success>
 			<xpath>/Defs/ThingDef[defName = "Telescope"]/comps</xpath>
-			<value>
-				<li Class="CompProperties_Styleable" />
-			</value>
-		</match>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "Telescope"]</xpath>
+				<value>
+					<comps>
+						<li Class="CompProperties_Styleable" />
+					</comps>
+				</value>
+			</nomatch>
+			<match Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "Telescope"]/comps</xpath>
+				<value>
+					<li Class="CompProperties_Styleable" />
+				</value>
+			</match>
+		</nomatch>
 	</Operation>
 
 

--- a/1.4/Patches/MakingFurnitureStyleable/WallPatch.xml
+++ b/1.4/Patches/MakingFurnitureStyleable/WallPatch.xml
@@ -6,21 +6,25 @@
 
 	<Operation Class="PatchOperationConditional">
 		<success>Always</success>
-		<xpath>/Defs/ThingDef[defName = "Wall"]/comps</xpath>
-		<nomatch Class="PatchOperationAdd">
-			<xpath>/Defs/ThingDef[defName = "Wall"]</xpath>
-			<value>
-				<comps>
-					<li Class="CompProperties_Styleable" />
-				</comps>
-			</value>
-		</nomatch>
-		<match Class="PatchOperationAdd">
+		<xpath>/Defs/ThingDef[defName = "Wall"]/comps/li[@Class = "CompProperties_Styleable"]</xpath>
+		<nomatch Class="PatchOperationConditional">
+			<success>Always</success>
 			<xpath>/Defs/ThingDef[defName = "Wall"]/comps</xpath>
-			<value>
-				<li Class="CompProperties_Styleable" />
-			</value>
-		</match>
+			<nomatch Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "Wall"]</xpath>
+				<value>
+					<comps>
+						<li Class="CompProperties_Styleable" />
+					</comps>
+				</value>
+			</nomatch>
+			<match Class="PatchOperationAdd">
+				<xpath>/Defs/ThingDef[defName = "Wall"]/comps</xpath>
+				<value>
+					<li Class="CompProperties_Styleable" />
+				</value>
+			</match>
+		</nomatch>
 	</Operation>
 
 


### PR DESCRIPTION
This should help with compatibility with mods that do that as well - if another mod added it before this one, it'll skip adding it (and prevent errors on game load).

This PR basically surrounds the patch operations adding the `CompProperties_Styleable` with another one that checks if the thing contains it first, and only adds it if it fails.