### PR TITLE
Fix errors when exposing data due to wrong scribe LookMode

### DIFF
--- a/1.5/Source/AlphaMemes/AlphaMemes/Rituals/FuneralFramework/RitualPositions/RitualPosition_CenterPos.cs
+++ b/1.5/Source/AlphaMemes/AlphaMemes/Rituals/FuneralFramework/RitualPositions/RitualPosition_CenterPos.cs
@@ -25,7 +25,7 @@ namespace AlphaMemes
         public override void ExposeData()
         {
             base.ExposeData();
-			Scribe_Collections.Look(ref thingOffset, "thingOffset", LookMode.Value, LookMode.Value, ref tmpThingDefs, ref tmpVec3);
+			Scribe_Collections.Look(ref thingOffset, "thingOffset", LookMode.Def, LookMode.Value, ref tmpThingDefs, ref tmpVec3);
 		}
         public Dictionary<ThingDef, IntVec3> thingOffset = new Dictionary<ThingDef, IntVec3>();
 		private List<ThingDef> tmpThingDefs = new List<ThingDef>();

--- a/1.5/Source/AlphaMemes/AlphaMemes/Rituals/FuneralFramework/RitualPositions/RitualPosition_CorpsePosition.cs
+++ b/1.5/Source/AlphaMemes/AlphaMemes/Rituals/FuneralFramework/RitualPositions/RitualPosition_CorpsePosition.cs
@@ -46,7 +46,7 @@ namespace AlphaMemes
         public override void ExposeData()
         {
             base.ExposeData();
-			Scribe_Collections.Look(ref corpseOffset, "corpeOffset",LookMode.Value,LookMode.Value,ref tmpThingDefs,ref tmpVec3);
+			Scribe_Collections.Look(ref corpseOffset, "corpeOffset",LookMode.Def,LookMode.Value,ref tmpThingDefs,ref tmpVec3);
 			Scribe_Deep.Look(ref pawnPosition, "pawnPosition");
         }
 		public Dictionary<ThingDef,IntVec3> corpseOffset = new Dictionary<ThingDef,IntVec3>();


### PR DESCRIPTION
It seems that 2 defs in collections were exposed with `LookMode.Value` rather than `LookMode.Def`, which caused save/load errors. If I'm not mistaken, this only affected pyramid burials. This small change should fix it.