### PR TITLE
Fixes and improvements for funeral framework

### DIFF
--- a/1.5/Defs/Rituals/FuneralFramework/RitualDefs/InsectoidBurial.xml
+++ b/1.5/Defs/Rituals/FuneralFramework/RitualDefs/InsectoidBurial.xml
@@ -31,7 +31,7 @@
 			<label>insectoid herder</label>
 			<id>insectoidHerder</id>
 			<precept>IdeoRole_Moralist</precept>
-			<tag>InsectoidHerder</tag>
+			<tag>Moralist</tag>
 			<maxCount>1</maxCount>
 			<substitutable>false</substitutable>
 			<required>True</required>

--- a/1.5/Mods/VanillaMemesExpanded/Patches/InsectoidFuneral.xml
+++ b/1.5/Mods/VanillaMemesExpanded/Patches/InsectoidFuneral.xml
@@ -14,6 +14,13 @@
 		</value>
 	</Operation>
 	
+	<Operation Class="PatchOperationReplace">
+		<xpath>/Defs/RitualBehaviorDef[defName="AM_InsectoidFuneralBehavior"]/roles/li[@Class="RitualRoleTag"]/tag</xpath>
+		<value>
+			<tag>InsectoidHerder</tag>
+		</value>
+	</Operation>
+	
 	<Operation Class="PatchOperationAdd">
 		<xpath>/Defs/RitualObligationTargetFilterDef[defName="AM_InsectoidBurialTarget"]/thingDefs</xpath>
 		<value>

--- a/1.5/Source/AlphaMemes/AlphaMemes/AlphaMemes.csproj
+++ b/1.5/Source/AlphaMemes/AlphaMemes/AlphaMemes.csproj
@@ -359,6 +359,7 @@
     <Compile Include="Precepts\PreceptWorker_DespisedAnimal.cs" />
     <Compile Include="Precepts\Precept_DespisedAnimal.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Rituals\FuneralFramework\Harmony\RitualObligationTrigger_MemberCorpseDestroyed_Patch.cs" />
     <Compile Include="Rituals\Misc\Behaviours\RitualBehaviorWorker_MaddeningChant.cs" />
     <Compile Include="Rituals\FuneralFramework\AI\JobDriver\JobDriver_OcularBurial.cs" />
     <Compile Include="Rituals\FuneralFramework\AI\JobDriver\JobDriver_AnimaBurialLinking.cs" />

--- a/1.5/Source/AlphaMemes/AlphaMemes/Rituals/FuneralFramework/Harmony/Ideo_Notify_Patches.cs
+++ b/1.5/Source/AlphaMemes/AlphaMemes/Rituals/FuneralFramework/Harmony/Ideo_Notify_Patches.cs
@@ -45,28 +45,16 @@ namespace AlphaMemes
             {
                 if (Find.IdeoManager.classicMode) { return true;}
 
-                LordJob_Ritual_FuneralFramework lordJob = null;
-                Map map = Find.CurrentMap;
-                if(map == null) { return true; }//Turns out this can get called when map doesnt exist yet. At least character editor did it while loading a saved pawn...
-                var lord = map.lordManager.lords.FirstOrDefault(x => x.LordJob is LordJob_Ritual_FuneralFramework);
-                if(lord != null)
+                if (!Find.Maps.NullOrEmpty())
                 {
-                    lordJob = lord.LordJob as LordJob_Ritual_FuneralFramework;
-                    if(lordJob.corpse == member)
+                    foreach (var map in Find.Maps)
                     {
-                        return false;
+                        var lordJob = map.lordManager.lords.Select(x => x.LordJob).OfType<LordJob_Ritual_FuneralFramework>().FirstOrDefault();
+                        if(lordJob?.corpse == member)
+                        {
+                            return false;
+                        }
                     }
-                }
-                List<Precept_Ritual> rituals = __instance.GetAllPreceptsOfType<Precept_Ritual>().ToList();
-                if (rituals.Where(x => x.def.HasModExtension<FuneralPreceptExtension>()).Any(x => x.def.GetModExtension<FuneralPreceptExtension>().addNoCorpseFuneral))
-                {
-                    var noCorpse = rituals.FirstOrDefault(x => x.def.defName == "AM_FuneralNoCorpse");
-                    if (noCorpse != null)
-                    {
-                        noCorpse.obligationTriggers.First().Notify_MemberCorpseDestroyed(member);
-                        return false;
-                    }
-
                 }
                 return true;
             }

--- a/1.5/Source/AlphaMemes/AlphaMemes/Rituals/FuneralFramework/Harmony/RitualObligationTrigger_MemberCorpseDestroyed_Patch.cs
+++ b/1.5/Source/AlphaMemes/AlphaMemes/Rituals/FuneralFramework/Harmony/RitualObligationTrigger_MemberCorpseDestroyed_Patch.cs
@@ -1,0 +1,21 @@
+﻿using HarmonyLib;
+using RimWorld;
+
+namespace AlphaMemes
+{
+    public static class RitualObligationTrigger_MemberCorpseDestroyed_Patch
+    {
+        // Prevent the vanilla no-corpse funeral, since AM adds its own one.
+        // In previous versions this was not needed as a different patch completely
+        // prevented it from running, but that patch was very destructive and removed.
+        [HarmonyPatch(typeof(RitualObligationTrigger_MemberCorpseDestroyed))]
+        [HarmonyPatch(nameof(RitualObligationTrigger_MemberCorpseDestroyed.Notify_MemberCorpseDestroyed))]
+        public static class FuneralFramework_RitualObligationTrigger_MemberCorpseDestroyed
+        {
+            static bool Prefix(RitualObligationTrigger_MemberCorpseDestroyed __instance)
+            {
+                return __instance.ritual?.def != PreceptDefOf.Funeral;
+            }
+        }
+    }
+}

--- a/1.5/Source/AlphaMemes/AlphaMemes/Rituals/FuneralFramework/LordJob/LordJob_Ritual_FuneralFramework.cs
+++ b/1.5/Source/AlphaMemes/AlphaMemes/Rituals/FuneralFramework/LordJob/LordJob_Ritual_FuneralFramework.cs
@@ -93,7 +93,7 @@ namespace AlphaMemes
 		}
 		protected override bool ShouldCallOffBecausePawnNoLongerOwned(Pawn p)
         {
-            return !(p == corpse);
+            return p != corpse;
         }
 
         public override void ExposeData()

--- a/1.5/Source/AlphaMemes/AlphaMemes/Rituals/FuneralFramework/RitualBehavior/RitualBehaviorWorker_FuneralFramework.cs
+++ b/1.5/Source/AlphaMemes/AlphaMemes/Rituals/FuneralFramework/RitualBehavior/RitualBehaviorWorker_FuneralFramework.cs
@@ -232,7 +232,7 @@ namespace AlphaMemes
             base.Cleanup(ritual);
             if (deregisteredCorpse)
             {
-                if(!corpse.Corpse?.Bugged ?? false && !ritual.Map.dynamicDrawManager.DrawThings.Contains(corpse.Corpse))
+                if((!corpse.Corpse?.Bugged ?? false) && !ritual.Map.dynamicDrawManager.DrawThings.Contains(corpse.Corpse))
                 {
                     ritual.Map.dynamicDrawManager.RegisterDrawable(corpse.Corpse);
                 }                  

--- a/1.5/Source/AlphaMemes/AlphaMemes/Rituals/FuneralFramework/RitualTargetWorker/TargetFilters/RitualObligationTargetWorker_FuneralThingNeedsPower.cs
+++ b/1.5/Source/AlphaMemes/AlphaMemes/Rituals/FuneralFramework/RitualTargetWorker/TargetFilters/RitualObligationTargetWorker_FuneralThingNeedsPower.cs
@@ -25,13 +25,9 @@ namespace AlphaMemes
             Thing thing = target.Thing;
            
             CompPowerTrader compPowerTrader = thing.TryGetComp<CompPowerTrader>();
-			if (compPowerTrader != null)
+			if (compPowerTrader != null && !compPowerTrader.PowerOn)
 			{
-				if (compPowerTrader.PowerNet == null || !compPowerTrader.PowerNet.HasActivePowerSource)
-				{
-                    return "Funeral_NeedsPower".Translate(target.Thing.def.label);
-                    
-                }				
+                return "Funeral_NeedsPower".Translate(target.Thing.def.label);
 			}
             
             return true;

--- a/1.5/Source/AlphaMemes/AlphaMemes/Rituals/FuneralFramework/RitualTriggers/RitualObligationTrigger_NoCorpse.cs
+++ b/1.5/Source/AlphaMemes/AlphaMemes/Rituals/FuneralFramework/RitualTriggers/RitualObligationTrigger_NoCorpse.cs
@@ -20,16 +20,58 @@ namespace AlphaMemes
             {
                 return;
             }
+            if (ModsConfig.AnomalyActive && (p.IsCreepJoiner || p.IsMutant || p.health.hediffSet.HasHediff(HediffDefOf.ShamblerCorpse)))
+            {
+                return;
+            }
             List<Precept_Ritual> rituals = ritual.ideo.GetAllPreceptsOfType<Precept_Ritual>().ToList();
-            if (rituals.Where(x => x.def.HasModExtension<FuneralPreceptExtension>()).Any(x => x.def.GetModExtension<FuneralPreceptExtension>().addNoCorpseFuneral))
+            if (rituals.Any(x => x.def.GetModExtension<FuneralPreceptExtension>()?.addNoCorpseFuneral == true))
             {
                 this.ritual.AddObligation(new RitualObligation(this.ritual, p, true));
             }
         }
 
+        public override void Notify_RitualExecuted(LordJob_Ritual ritualJob)
+        {
+            base.Notify_RitualExecuted(ritualJob);
 
+            // Only run the cleanup code for AM's no funeral corpse, and no other rituals that (may) use this obligation trigger.
+            if (ritual?.def.defName != "AM_FuneralNoCorpse")
+            {
+                return;
+            }
 
+            // Make sure the lord job and ritual aren't null and the obligation has a target (corpse).
+            if (ritualJob?.Ritual?.ideo == null || ritualJob.obligation?.FirstValidTarget.HasThing != true)
+            {
+                return;
+            }
 
+            // Only run the cleanup if the ritual that just ended is a funeral.
+            if (ritualJob.Ritual.def.defName != "AM_FuneralNoCorpse" && !ritualJob.Ritual.def.HasModExtension<FuneralPreceptExtension>())
+            {
+                return;
+            }
+
+            var corpse = ritualJob.obligation.targetA;
+
+            foreach (var precept in ritualJob.Ritual.ideo.GetAllPreceptsOfType<Precept_Ritual>().Where(x => x.activeObligations != null))
+            {
+                // Only remove obligations from funeral rituals.
+                if (precept.def.HasModExtension<FuneralPreceptExtension>() || precept.def.defName == "AM_FuneralNoCorpse")
+                {
+                    // Using a reverse for loop since we're removing stuff from the list as we go
+                    for (var i = precept.activeObligations.Count - 1; i >= 0; i--)
+                    {
+                        var ritualObligation = precept.activeObligations[i];
+                        if (ritualObligation.FirstValidTarget == corpse)
+                        {
+                            precept.RemoveObligation(ritualObligation);
+                        }
+                    }
+                }
+            }
+        }
     }        
 
 


### PR DESCRIPTION
Additions:

`FuneralFramework_RitualObligationTrigger_MemberCorpseDestroyed`
- A new patch to prevent the vanilla no funeral corpse
  - This is now required due to changes with `FuneralFramework_Ideo_MemberCorpseDestroyed`

Changes:

`FuneralFramework_Ideo_MemberCorpseDestroyed`
- Modified the code to check all maps for rituals, rather than the one the player is currently looking attempt
- Removed the code to trigger no corpse funeral, as the patch was more destructive than it needed to
  - The code to trigger a no corpse funeral will still run, as that's what the original code was going to do
  - This removes a redundant check if a no corpse funeral should be added, as the ritual obligation already checked it
  - If there was at least a single no corpse funeral, it would cancel the execution of the vanilla method, which may have potentially broken some mods
  - Additional patch to disable vanilla no corpse funeral was needed (`FuneralFramework_RitualObligationTrigger_MemberCorpseDestroyed`), as this patch previously prevented it from triggering

`LordJob_Ritual_FuneralFramework`
- Changed `!(p == corpse)` to `p != corpse`, as using `!=` operator is clearer than negating a `==` operator

`RitualBehaviorWorker_FuneralFramework`
- Fixed the `Cleanup` method skipping a check if `ritual.Map.dynamicDrawManager.DrawThings` contains the corpse
  - This could have ended up with calling `ritual.Map.dynamicDrawManager.RegisterDrawable` when it wasn't supposed to be

`RitualObligationTargetWorker_FuneralThingNeedsPower`
- Fixed the check for power
  - Currently the code was checking if the thing was connected to a power network, but not if it actually had power (so it could be used while off/broken/during solar flare/with not enough power)

`RitualObligationTrigger_NoCorpse`
- Disable no corpse funerals for creep joiners/mutants/shamblers
  - This matches vanilla behaviour of no corpse funerals
- Slightly changed the check if a no corpse funeral should be added to avoid iterating twice over def mod extensions list
- Added a code to remove all funeral obligations for a specific pawn they just had a funeral
  - The code was added to `RitualObligationTrigger_NoCorpse` as one is guaranteed to exist on no funeral corpse ritual (`AM_FuneralNoCorpse`)
  - It will only run if the obligation trigger's ritual is `AM_FuneralNoCorpse` to avoid multiple calls to remove extra funeral obligations

`RitualOutcomeEffectWorker_InsectoidBurial`
- Fixed errors with pawn spawning
  - An incorrect `PawnGenerationRequest` constructor was used, as RW requires the use of a single-parameter constructor
  - Added `PawnGenerationContext.NonPlayer` as context, as `PawnGenerationContext.All` is not supported
- Modified the code to get possible pawn spawn list from a vanilla `CompSpawnerPawn`, as well as VFE-I2 `CompHive` and `CompInsectSpawner`
- Modified the code to get possible pawn spawn list from Alpha Animals/VFE-I1 to work in a safer and a little less destructive manner (don't modify the list from the mod itself)
- Included some extra sanity checks
- Modified the code to attempt to acquire pawn list from any source, as long as the previous one provided a null/empty list

`InsectoidBurial.xml` (def) and `InsectoidFuneral.xml` (patch)
- Modified the def to properly support a moral guide as the target role by changing the `tag`
  - This fixes an issue that made the funeral impossible to do if Vanilla Ideology Expanded - Memes and Structures was inactive
- Added additional patch to change the `tag` back to what it was if Vanilla Ideology Expanded - Memes and Structures is enabled