### PR TITLE
Make the patch removing maternal mortality check for proper precept

### DIFF
--- a/1.5/Source/AlphaMemes/AlphaMemes/Harmony/PregnancyUtility_ChanceMomDiesDuringBirth.cs
+++ b/1.5/Source/AlphaMemes/AlphaMemes/Harmony/PregnancyUtility_ChanceMomDiesDuringBirth.cs
@@ -20,7 +20,7 @@ namespace AlphaMemes
         [HarmonyPostfix]
         static void RemoveMaternalMortality(ref float __result)
         {
-            if (Current.Game.World.factionManager.OfPlayer.ideos.GetPrecept(InternalDefOf.AM_ArtProductionSpeed_Increased) != null)
+            if (Current.Game.World.factionManager.OfPlayer.ideos.GetPrecept(InternalDefOf.AM_MaternalMortality_Nullified) != null)
             {
                 __result= 0f;
             }


### PR DESCRIPTION
The Harmony patch removing maternal mortality was checking for the "art production speed: increased" precept, rather than "maternal mortality: nullified". Likely some leftover from testing before the actual precept was introduced?