### PR TITLE
Update patches/styles related to VWE

### DIFF
--- a/1.6/Defs/ThingStyleDefs/Alpha/ThingStyleDefs_Corsair.xml
+++ b/1.6/Defs/ThingStyleDefs/Alpha/ThingStyleDefs_Corsair.xml
@@ -389,13 +389,13 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 	</ThingStyleDef>
-	<ThingStyleDef ParentName="AM_RotateWeapons">
+	<!--<ThingStyleDef ParentName="AM_RotateWeapons">
 		<defName>AM_Corsair_ChargeSniperRifle</defName>
 		<graphicData>
 			<texPath>Things/Weapons/Corsair/AM_CorsairChargeSniper</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
-	</ThingStyleDef>
+	</ThingStyleDef>-->
 	<ThingStyleDef ParentName="AM_RotateWeapons">
 		<defName>AM_Corsair_ChargeMinigun</defName>
 		<graphicData>

--- a/1.6/Defs/ThingStyleDefs/Alpha/ThingStyleDefs_Kemetic.xml
+++ b/1.6/Defs/ThingStyleDefs/Alpha/ThingStyleDefs_Kemetic.xml
@@ -550,13 +550,13 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 	</ThingStyleDef>
-	<ThingStyleDef ParentName="AM_RotateWeapons">
+	<!--<ThingStyleDef ParentName="AM_RotateWeapons">
 		<defName>AM_Kemetic_ChargeSniperRifle</defName>
 		<graphicData>
 			<texPath>Things/Weapons/Kemetic/AM_KemeticChargeSniper</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
-	</ThingStyleDef>
+	</ThingStyleDef>-->
 	<ThingStyleDef ParentName="AM_RotateWeapons">
 		<defName>AM_Kemetic_ChargeMinigun</defName>
 		<graphicData>

--- a/1.6/Defs/ThingStyleDefs/Vanilla/ThingStyleDefs_Animalist.xml
+++ b/1.6/Defs/ThingStyleDefs/Vanilla/ThingStyleDefs_Animalist.xml
@@ -347,13 +347,13 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 	</ThingStyleDef>
-	<ThingStyleDef ParentName="AM_RotateWeapons">
+  <!--<ThingStyleDef ParentName="AM_RotateWeapons">
 		<defName>AM_Animalist_ChargeSniperRifle</defName>
 		<graphicData>
 			<texPath>Things/Weapons/Animalist/AM_AnimalistChargeSniper</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
-	</ThingStyleDef>
+	</ThingStyleDef>-->
 	<ThingStyleDef ParentName="AM_RotateWeapons">
 		<defName>AM_Animalist_ChargeMinigun</defName>
 		<graphicData>

--- a/1.6/Defs/ThingStyleDefs/Vanilla/ThingStyleDefs_Rustic.xml
+++ b/1.6/Defs/ThingStyleDefs/Vanilla/ThingStyleDefs_Rustic.xml
@@ -247,13 +247,13 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 	</ThingStyleDef>
-	<ThingStyleDef ParentName="AM_RotateWeapons">
+	<!--<ThingStyleDef ParentName="AM_RotateWeapons">
 		<defName>AM_Rustic_ChargeSniperRifle</defName>
 		<graphicData>
 			<texPath>Things/Weapons/Rustic/AM_RusticChargeSniper</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
-	</ThingStyleDef>
+	</ThingStyleDef>-->
 	<ThingStyleDef ParentName="AM_RotateWeapons">
 		<defName>AM_Rustic_ChargeMinigun</defName>
 		<graphicData>

--- a/1.6/Defs/ThingStyleDefs/Vanilla/ThingStyleDefs_Spikecore.xml
+++ b/1.6/Defs/ThingStyleDefs/Vanilla/ThingStyleDefs_Spikecore.xml
@@ -233,13 +233,13 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 	</ThingStyleDef>
-	<ThingStyleDef ParentName="AM_RotateWeapons">
+	<!--<ThingStyleDef ParentName="AM_RotateWeapons">
 		<defName>AM_Spikecore_ChargeSniperRifle</defName>
 		<graphicData>
 			<texPath>Things/Weapons/Spikecore/AM_SpikecoreChargeSniper</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
-	</ThingStyleDef>
+	</ThingStyleDef>-->
 	<ThingStyleDef ParentName="AM_RotateWeapons">
 		<defName>AM_Spikecore_ChargeMinigun</defName>
 		<graphicData>

--- a/1.6/Defs/ThingStyleDefs/Vanilla/ThingStyleDefs_Techist.xml
+++ b/1.6/Defs/ThingStyleDefs/Vanilla/ThingStyleDefs_Techist.xml
@@ -242,13 +242,13 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 	</ThingStyleDef>
-	<ThingStyleDef ParentName="AM_RotateWeapons">
+	<!--<ThingStyleDef ParentName="AM_RotateWeapons">
 		<defName>AM_Techist_ChargeSniperRifle</defName>
 		<graphicData>
 			<texPath>Things/Weapons/Techist/AM_TechistChargeSniper</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
-	</ThingStyleDef>
+	</ThingStyleDef>-->
 	<ThingStyleDef ParentName="AM_RotateWeapons">
 		<defName>AM_Techist_ChargeMinigun</defName>
 		<graphicData>

--- a/1.6/Defs/ThingStyleDefs/Vanilla/ThingStyleDefs_Totemic.xml
+++ b/1.6/Defs/ThingStyleDefs/Vanilla/ThingStyleDefs_Totemic.xml
@@ -249,13 +249,13 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 	</ThingStyleDef>
-	<ThingStyleDef ParentName="AM_RotateWeapons">
+	<!--<ThingStyleDef ParentName="AM_RotateWeapons">
 		<defName>AM_Totemic_ChargeSniperRifle</defName>
 		<graphicData>
 			<texPath>Things/Weapons/Totemic/AM_TotemicChargeSniper</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
-	</ThingStyleDef>
+	</ThingStyleDef>-->
 	<ThingStyleDef ParentName="AM_RotateWeapons">
 		<defName>AM_Totemic_ChargeMinigun</defName>
 		<graphicData>

--- a/1.6/Mods/Anomaly/Defs/ThingStyleDefs/Alpha/ThingStyleDefs_Horaxian.xml
+++ b/1.6/Mods/Anomaly/Defs/ThingStyleDefs/Alpha/ThingStyleDefs_Horaxian.xml
@@ -536,13 +536,13 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 	</ThingStyleDef>
-	<ThingStyleDef ParentName="AM_RotateWeapons">
+	<!--<ThingStyleDef ParentName="AM_RotateWeapons">
 		<defName>AM_Horaxian_ChargeSniperRifle</defName>
 		<graphicData>
 			<texPath>Things/Weapons/Horaxian/AM_HoraxianChargeSniper</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
-	</ThingStyleDef>
+	</ThingStyleDef>-->
 	<ThingStyleDef ParentName="AM_RotateWeapons">
 		<defName>AM_Horaxian_ChargeMinigun</defName>
 		<graphicData>

--- a/1.6/Mods/Anomaly/Patches/HoraxianStylePatch.xml
+++ b/1.6/Mods/Anomaly/Patches/HoraxianStylePatch.xml
@@ -29,10 +29,10 @@
 								<thingDef>VWE_Gun_ChargeLMG</thingDef>
 								<styleDef>AM_Horaxian_ChargeLMG</styleDef>
 							</li>
-							<li>
+							<!--<li>
 								<thingDef>VWE_Gun_ChargeSniperRifle</thingDef>
 								<styleDef>AM_Horaxian_ChargeSniperRifle</styleDef>
-							</li>
+							</li>-->
 							<li>
 								<thingDef>VWE_Gun_ChargeMinigun</thingDef>
 								<styleDef>AM_Horaxian_ChargeMinigun</styleDef>
@@ -74,10 +74,6 @@
 								<styleDef>AM_Horaxian_Crossbow</styleDef>
 							</li>
 							<li>
-								<thingDef>VWE_Gun_Flintlock</thingDef>
-								<styleDef>AM_Horaxian_Flintlock</styleDef>
-							</li>
-							<li>
 								<thingDef>VWE_Gun_HMG</thingDef>
 								<styleDef>AM_Horaxian_HMG</styleDef>
 							</li>
@@ -109,10 +105,6 @@
 								<thingDef>VWE_Gun_MarksmanRifle</thingDef>
 								<styleDef>AM_Horaxian_MarksmanRifle</styleDef>
 							</li>
-							<li>
-								<thingDef>VWE_Gun_Musket</thingDef>
-								<styleDef>AM_Horaxian_Musket</styleDef>
-							</li>
 						</value>
 					</match>
 				</li>
@@ -141,7 +133,32 @@
 			</operations>
 		</match>
 	</Operation>
-	
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Vanilla Factions Expanded - Medieval 2</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+        <li Class="PatchOperationConditional">
+          <success>Always</success>
+          <xpath>/Defs/StyleCategoryDef[defName = "AM_Horaxian"]/thingDefStyles</xpath>
+          <match Class="PatchOperationAdd">
+            <xpath>/Defs/StyleCategoryDef[defName = "AM_Horaxian"]/thingDefStyles</xpath>
+            <value>
+              <li>
+                <thingDef>VFEM2_Gun_Flintlock</thingDef>
+                <styleDef>AM_Horaxian_Flintlock</styleDef>
+              </li>
+              <li>
+                <thingDef>VFEM2_Gun_Musket</thingDef>
+                <styleDef>AM_Horaxian_Musket</styleDef>
+              </li>
+            </value>
+          </match>
+        </li>
+      </operations>
+    </match>
+  </Operation>
 	
 
 	

--- a/1.6/Patches/AlphaStylePatches/CorsairStylePatch.xml
+++ b/1.6/Patches/AlphaStylePatches/CorsairStylePatch.xml
@@ -28,10 +28,10 @@
 								<thingDef>VWE_Gun_ChargeLMG</thingDef>
 								<styleDef>AM_Corsair_ChargeLMG</styleDef>
 							</li>
-							<li>
+							<!--<li>
 								<thingDef>VWE_Gun_ChargeSniperRifle</thingDef>
 								<styleDef>AM_Corsair_ChargeSniperRifle</styleDef>
-							</li>
+							</li>-->
 							<li>
 								<thingDef>VWE_Gun_ChargeMinigun</thingDef>
 								<styleDef>AM_Corsair_ChargeMinigun</styleDef>
@@ -73,10 +73,6 @@
 								<styleDef>AM_Corsair_Crossbow</styleDef>
 							</li>
 							<li>
-								<thingDef>VWE_Gun_Flintlock</thingDef>
-								<styleDef>AM_Corsair_Flintlock</styleDef>
-							</li>
-							<li>
 								<thingDef>VWE_Gun_HMG</thingDef>
 								<styleDef>AM_Corsair_HMG</styleDef>
 							</li>
@@ -108,10 +104,6 @@
 								<thingDef>VWE_Gun_MarksmanRifle</thingDef>
 								<styleDef>AM_Corsair_MarksmanRifle</styleDef>
 							</li>
-							<li>
-								<thingDef>VWE_Gun_Musket</thingDef>
-								<styleDef>AM_Corsair_Musket</styleDef>
-							</li>
 						</value>
 					</match>
 				</li>
@@ -140,4 +132,30 @@
 			</operations>
 		</match>
 	</Operation>
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Vanilla Factions Expanded - Medieval 2</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+        <li Class="PatchOperationConditional">
+          <success>Always</success>
+          <xpath>/Defs/StyleCategoryDef[defName = "AM_Corsair"]/thingDefStyles</xpath>
+          <match Class="PatchOperationAdd">
+            <xpath>/Defs/StyleCategoryDef[defName = "AM_Corsair"]/thingDefStyles</xpath>
+            <value>
+              <li>
+                <thingDef>VFEM2_Gun_Flintlock</thingDef>
+                <styleDef>AM_Corsair_Flintlock</styleDef>
+              </li>
+              <li>
+                <thingDef>VFEM2_Gun_Musket</thingDef>
+                <styleDef>AM_Corsair_Musket</styleDef>
+              </li>
+            </value>
+          </match>
+        </li>
+      </operations>
+    </match>
+  </Operation>
 </Patch>

--- a/1.6/Patches/AlphaStylePatches/KemeticStylePatch.xml
+++ b/1.6/Patches/AlphaStylePatches/KemeticStylePatch.xml
@@ -33,10 +33,10 @@
 								<thingDef>VWE_Gun_ChargeLMG</thingDef>
 								<styleDef>AM_Kemetic_ChargeLMG</styleDef>
 							</li>
-							<li>
+							<!--<li>
 								<thingDef>VWE_Gun_ChargeSniperRifle</thingDef>
 								<styleDef>AM_Kemetic_ChargeSniperRifle</styleDef>
-							</li>
+							</li>-->
 							<li>
 								<thingDef>VWE_Gun_ChargeMinigun</thingDef>
 								<styleDef>AM_Kemetic_ChargeMinigun</styleDef>
@@ -78,10 +78,6 @@
 								<styleDef>AM_Kemetic_Crossbow</styleDef>
 							</li>
 							<li>
-								<thingDef>VWE_Gun_Flintlock</thingDef>
-								<styleDef>AM_Kemetic_Flintlock</styleDef>
-							</li>
-							<li>
 								<thingDef>VWE_Gun_HMG</thingDef>
 								<styleDef>AM_Kemetic_HMG</styleDef>
 							</li>
@@ -113,10 +109,6 @@
 							<li>
 								<thingDef>VWE_Gun_MarksmanRifle</thingDef>
 								<styleDef>AM_Kemetic_MarksmanRifle</styleDef>
-							</li>
-							<li>
-								<thingDef>VWE_Gun_Musket</thingDef>
-								<styleDef>AM_Kemetic_Musket</styleDef>
 							</li>
 							
 
@@ -208,8 +200,32 @@
 			</operations>
 		</match>
 	</Operation>
-
-
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Vanilla Factions Expanded - Medieval 2</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+        <li Class="PatchOperationConditional">
+          <success>Always</success>
+          <xpath>/Defs/StyleCategoryDef[defName = "AM_Kemetic"]/thingDefStyles</xpath>
+          <match Class="PatchOperationAdd">
+            <xpath>/Defs/StyleCategoryDef[defName = "AM_Kemetic"]/thingDefStyles</xpath>
+            <value>
+              <li>
+                <thingDef>VFEM2_Gun_Flintlock</thingDef>
+                <styleDef>AM_Kemetic_Flintlock</styleDef>
+              </li>
+              <li>
+                <thingDef>VFEM2_Gun_Musket</thingDef>
+                <styleDef>AM_Kemetic_Musket</styleDef>
+              </li>
+            </value>
+          </match>
+        </li>
+      </operations>
+    </match>
+  </Operation>
 
 
 

--- a/1.6/Patches/VanillaStylePatches/AnimalistStylePatch.xml
+++ b/1.6/Patches/VanillaStylePatches/AnimalistStylePatch.xml
@@ -207,10 +207,10 @@
 											<thingDef>VWE_Gun_ChargeLMG</thingDef>
 											<styleDef>AM_Animalist_ChargeLMG</styleDef>
 										</li>
-										<li>
+										<!--<li>
 											<thingDef>VWE_Gun_ChargeSniperRifle</thingDef>
 											<styleDef>AM_Animalist_ChargeSniperRifle</styleDef>
-										</li>
+										</li>-->
 										<li>
 											<thingDef>VWE_Gun_ChargeMinigun</thingDef>
 											<styleDef>AM_Animalist_ChargeMinigun</styleDef>
@@ -230,10 +230,6 @@
 										<li>
 											<thingDef>VWE_Bow_Crossbow</thingDef>
 											<styleDef>AM_Animalist_Crossbow</styleDef>
-										</li>
-										<li>
-											<thingDef>VWE_Gun_Flintlock</thingDef>
-											<styleDef>AM_Animalist_Flintlock</styleDef>
 										</li>
 										<li>
 											<thingDef>VWE_SawedOffShotgun</thingDef>
@@ -258,10 +254,6 @@
 										<li>
 											<thingDef>VWE_Gun_MarksmanRifle</thingDef>
 											<styleDef>AM_Animalist_MarksmanRifle</styleDef>
-										</li>
-										<li>
-											<thingDef>VWE_Gun_Musket</thingDef>
-											<styleDef>AM_Animalist_Musket</styleDef>
 										</li>
 									</value>
 								</match>
@@ -324,4 +316,30 @@
 			</operations>
 		</nomatch>
 	</Operation>
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Vanilla Factions Expanded - Medieval 2</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+        <li Class="PatchOperationConditional">
+          <success>Always</success>
+          <xpath>/Defs/StyleCategoryDef[defName = "Animalist"]/thingDefStyles</xpath>
+          <match Class="PatchOperationAdd">
+            <xpath>/Defs/StyleCategoryDef[defName = "Animalist"]/thingDefStyles</xpath>
+            <value>
+              <li>
+                <thingDef>VFEM2_Gun_Flintlock</thingDef>
+                <styleDef>AM_Animalist_Flintlock</styleDef>
+              </li>
+              <li>
+                <thingDef>VFEM2_Gun_Musket</thingDef>
+                <styleDef>AM_Animalist_Musket</styleDef>
+              </li>
+            </value>
+          </match>
+        </li>
+      </operations>
+    </match>
+  </Operation>
 </Patch>

--- a/1.6/Patches/VanillaStylePatches/RusticStylePatch.xml
+++ b/1.6/Patches/VanillaStylePatches/RusticStylePatch.xml
@@ -185,10 +185,10 @@
 								<thingDef>VWE_Gun_ChargeLMG</thingDef>
 								<styleDef>AM_Rustic_ChargeLMG</styleDef>
 							</li>
-							<li>
+							<!--<li>
 								<thingDef>VWE_Gun_ChargeSniperRifle</thingDef>
 								<styleDef>AM_Rustic_ChargeSniperRifle</styleDef>
-							</li>
+							</li>-->
 							<li>
 								<thingDef>VWE_Gun_ChargeMinigun</thingDef>
 								<styleDef>AM_Rustic_ChargeMinigun</styleDef>
@@ -226,10 +226,6 @@
 								<styleDef>AM_Rustic_Crossbow</styleDef>
 							</li>
 							<li>
-								<thingDef>VWE_Gun_Flintlock</thingDef>
-								<styleDef>AM_Rustic_Flintlock</styleDef>
-							</li>
-							<li>
 								<thingDef>VWE_Gun_HMG</thingDef>
 								<styleDef>AM_Rustic_HMG</styleDef>
 							</li>
@@ -261,10 +257,6 @@
 								<thingDef>VWE_Gun_MarksmanRifle</thingDef>
 								<styleDef>AM_Rustic_MarksmanRifle</styleDef>
 							</li>
-							<li>
-								<thingDef>VWE_Gun_Musket</thingDef>
-								<styleDef>AM_Rustic_Musket</styleDef>
-							</li>
 						</value>
 					</match>
 				</li>
@@ -293,4 +285,30 @@
 			</operations>
 		</match>
 	</Operation>
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Vanilla Factions Expanded - Medieval 2</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+        <li Class="PatchOperationConditional">
+          <success>Always</success>
+          <xpath>/Defs/StyleCategoryDef[defName = "Rustic"]/thingDefStyles</xpath>
+          <match Class="PatchOperationAdd">
+            <xpath>/Defs/StyleCategoryDef[defName = "Rustic"]/thingDefStyles</xpath>
+            <value>
+              <li>
+                <thingDef>VFEM2_Gun_Flintlock</thingDef>
+                <styleDef>AM_Rustic_Flintlock</styleDef>
+              </li>
+              <li>
+                <thingDef>VFEM2_Gun_Musket</thingDef>
+                <styleDef>AM_Rustic_Musket</styleDef>
+              </li>
+            </value>
+          </match>
+        </li>
+      </operations>
+    </match>
+  </Operation>
 </Patch>

--- a/1.6/Patches/VanillaStylePatches/SpikecoreStylePatch.xml
+++ b/1.6/Patches/VanillaStylePatches/SpikecoreStylePatch.xml
@@ -190,10 +190,10 @@
 								<thingDef>VWE_Gun_ChargeLMG</thingDef>
 								<styleDef>AM_Spikecore_ChargeLMG</styleDef>
 							</li>
-							<li>
+							<!--<li>
 								<thingDef>VWE_Gun_ChargeSniperRifle</thingDef>
 								<styleDef>AM_Spikecore_ChargeSniperRifle</styleDef>
-							</li>
+							</li>-->
 							<li>
 								<thingDef>VWE_Gun_ChargeMinigun</thingDef>
 								<styleDef>AM_Spikecore_ChargeMinigun</styleDef>
@@ -223,10 +223,6 @@
 							<li>
 								<thingDef>VWE_Bow_Crossbow</thingDef>
 								<styleDef>AM_Spikecore_Crossbow</styleDef>
-							</li>
-							<li>
-								<thingDef>VWE_Gun_Flintlock</thingDef>
-								<styleDef>AM_Spikecore_Flintlock</styleDef>
 							</li>
 							<li>
 								<thingDef>VWE_Gun_HMG</thingDef>
@@ -260,5 +256,27 @@
 			</operations>
 		</match>
 	</Operation>
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Vanilla Factions Expanded - Medieval 2</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+        <li Class="PatchOperationConditional">
+          <success>Always</success>
+          <xpath>/Defs/StyleCategoryDef[defName = "Spikecore"]/thingDefStyles</xpath>
+          <match Class="PatchOperationAdd">
+            <xpath>/Defs/StyleCategoryDef[defName = "Spikecore"]/thingDefStyles</xpath>
+            <value>
+              <li>
+                <thingDef>VFEM2_Gun_Flintlock</thingDef>
+                <styleDef>AM_Spikecore_Flintlock</styleDef>
+              </li>
+            </value>
+          </match>
+        </li>
+      </operations>
+    </match>
+  </Operation>
 
 </Patch>

--- a/1.6/Patches/VanillaStylePatches/TechistStylePatch.xml
+++ b/1.6/Patches/VanillaStylePatches/TechistStylePatch.xml
@@ -182,10 +182,10 @@
 								<thingDef>VWE_Gun_ChargeLMG</thingDef>
 								<styleDef>AM_Techist_ChargeLMG</styleDef>
 							</li>
-							<li>
+							<!--<li>
 								<thingDef>VWE_Gun_ChargeSniperRifle</thingDef>
 								<styleDef>AM_Techist_ChargeSniperRifle</styleDef>
-							</li>
+							</li>-->
 							<li>
 								<thingDef>VWE_Gun_ChargeMinigun</thingDef>
 								<styleDef>AM_Techist_ChargeMinigun</styleDef>
@@ -227,10 +227,6 @@
 								<styleDef>AM_Techist_Crossbow</styleDef>
 							</li>
 							<li>
-								<thingDef>VWE_Gun_Flintlock</thingDef>
-								<styleDef>AM_Techist_Flintlock</styleDef>
-							</li>
-							<li>
 								<thingDef>VWE_Gun_HMG</thingDef>
 								<styleDef>AM_Techist_HMG</styleDef>
 							</li>
@@ -263,10 +259,6 @@
 								<thingDef>VWE_Gun_MarksmanRifle</thingDef>
 								<styleDef>AM_Techist_MarksmanRifle</styleDef>
 							</li>
-							<li>
-								<thingDef>VWE_Gun_Musket</thingDef>
-								<styleDef>AM_Techist_Musket</styleDef>
-							</li>
 						</value>
 					</match>
 				</li>
@@ -295,4 +287,30 @@
 			</operations>
 		</match>
 	</Operation>
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Vanilla Factions Expanded - Medieval 2</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+        <li Class="PatchOperationConditional">
+          <success>Always</success>
+          <xpath>/Defs/StyleCategoryDef[defName = "Techist"]/thingDefStyles</xpath>
+          <match Class="PatchOperationAdd">
+            <xpath>/Defs/StyleCategoryDef[defName = "Techist"]/thingDefStyles</xpath>
+            <value>
+              <li>
+                <thingDef>VFEM2_Gun_Flintlock</thingDef>
+                <styleDef>AM_Techist_Flintlock</styleDef>
+              </li>
+              <li>
+                <thingDef>VFEM2_Gun_Musket</thingDef>
+                <styleDef>AM_Techist_Musket</styleDef>
+              </li>
+            </value>
+          </match>
+        </li>
+      </operations>
+    </match>
+  </Operation>
 </Patch>

--- a/1.6/Patches/VanillaStylePatches/TotemicStylePatch.xml
+++ b/1.6/Patches/VanillaStylePatches/TotemicStylePatch.xml
@@ -183,10 +183,10 @@
 								<thingDef>VWE_Gun_ChargeLMG</thingDef>
 								<styleDef>AM_Totemic_ChargeLMG</styleDef>
 							</li>
-							<li>
+							<!--<li>
 								<thingDef>VWE_Gun_ChargeSniperRifle</thingDef>
 								<styleDef>AM_Totemic_ChargeSniperRifle</styleDef>
-							</li>
+							</li>-->
 							<li>
 								<thingDef>VWE_Gun_ChargeMinigun</thingDef>
 								<styleDef>AM_Totemic_ChargeMinigun</styleDef>
@@ -229,10 +229,6 @@
 								<styleDef>AM_Totemic_Crossbow</styleDef>
 							</li>
 							<li>
-								<thingDef>VWE_Gun_Flintlock</thingDef>
-								<styleDef>AM_Totemic_Flintlock</styleDef>
-							</li>
-							<li>
 								<thingDef>VWE_Gun_HMG</thingDef>
 								<styleDef>AM_Totemic_HMG</styleDef>
 							</li>
@@ -265,10 +261,6 @@
 								<thingDef>VWE_Gun_MarksmanRifle</thingDef>
 								<styleDef>AM_Totemic_MarksmanRifle</styleDef>
 							</li>
-							<li>
-								<thingDef>VWE_Gun_Musket</thingDef>
-								<styleDef>AM_Totemic_Musket</styleDef>
-							</li>
 							
 						</value>
 					</match>
@@ -298,4 +290,30 @@
 			</operations>
 		</match>
 	</Operation>
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Vanilla Factions Expanded - Medieval 2</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+        <li Class="PatchOperationConditional">
+          <success>Always</success>
+          <xpath>/Defs/StyleCategoryDef[defName = "Totemic"]/thingDefStyles</xpath>
+          <match Class="PatchOperationAdd">
+            <xpath>/Defs/StyleCategoryDef[defName = "Totemic"]/thingDefStyles</xpath>
+            <value>
+              <li>
+                <thingDef>VFEM2_Gun_Flintlock</thingDef>
+                <styleDef>AM_Totemic_Flintlock</styleDef>
+              </li>
+              <li>
+                <thingDef>VFEM2_Gun_Musket</thingDef>
+                <styleDef>AM_Totemic_Musket</styleDef>
+              </li>
+            </value>
+          </match>
+        </li>
+      </operations>
+    </match>
+  </Operation>
 </Patch>


### PR DESCRIPTION
Any styles for musket/flintlock are now checking for Medieval 2 defs and are using its defs.

All the charge sniper rifle styles were removed. They are only commented out for now, as the fate of the weapons is not 100% certain.