### PR TITLE
Fix duplicate CompProperties_Styleable on inherited ThingDefs

### DIFF
--- a/1.6/Patches/MakingFurnitureStyleable/ComponentsPatch.xml
+++ b/1.6/Patches/MakingFurnitureStyleable/ComponentsPatch.xml
@@ -1,56 +1,9 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Patch>
 
-
-	
-
-	<Operation Class="PatchOperationConditional">
-		<success>Always</success>
-		<xpath>/Defs/ThingDef[defName = "ComponentIndustrial"]/comps/li[@Class = "CompProperties_Styleable"]</xpath>
-		<nomatch Class="PatchOperationConditional">
-			<success>Always</success>
-			<xpath>/Defs/ThingDef[defName = "ComponentIndustrial"]/comps</xpath>
-			<nomatch Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName = "ComponentIndustrial"]</xpath>
-				<value>
-					<comps>
-						<li Class="CompProperties_Styleable" />
-					</comps>
-				</value>
-			</nomatch>
-			<match Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName = "ComponentIndustrial"]/comps</xpath>
-				<value>
-					<li Class="CompProperties_Styleable" />
-				</value>
-			</match>
-		</nomatch>
-	</Operation>
-	
-	<Operation Class="PatchOperationConditional">
-		<success>Always</success>
-		<xpath>/Defs/ThingDef[defName = "ComponentSpacer"]/comps/li[@Class = "CompProperties_Styleable"]</xpath>
-		<nomatch Class="PatchOperationConditional">
-			<success>Always</success>
-			<xpath>/Defs/ThingDef[defName = "ComponentSpacer"]/comps</xpath>
-			<nomatch Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName = "ComponentSpacer"]</xpath>
-				<value>
-					<comps>
-						<li Class="CompProperties_Styleable" />
-					</comps>
-				</value>
-			</nomatch>
-			<match Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName = "ComponentSpacer"]/comps</xpath>
-				<value>
-					<li Class="CompProperties_Styleable" />
-				</value>
-			</match>
-		</nomatch>
-	</Operation>
-
-
-
+	<!-- ComponentIndustrial and ComponentSpacer already inherit CompProperties_Styleable
+	     from their parent ResourceBase. Adding it again via XPath patch causes duplicate
+	     CompStyleable components, leading to duplicate sourcePrecept entries in save files
+	     and errors on load. The XPath conditional check doesn't detect inherited comps. -->
 
 </Patch>

--- a/1.6/Patches/MakingFurnitureStyleable/EndTablePatch.xml
+++ b/1.6/Patches/MakingFurnitureStyleable/EndTablePatch.xml
@@ -1,33 +1,9 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Patch>
 
-
-	
-
-	<Operation Class="PatchOperationConditional">
-		<success>Always</success>
-		<xpath>/Defs/ThingDef[defName = "EndTable"]/comps/li[@Class = "CompProperties_Styleable"]</xpath>
-		<nomatch Class="PatchOperationConditional">
-			<success>Always</success>
-			<xpath>/Defs/ThingDef[defName = "EndTable"]/comps</xpath>
-			<nomatch Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName = "EndTable"]</xpath>
-				<value>
-					<comps>
-						<li Class="CompProperties_Styleable" />
-					</comps>
-				</value>
-			</nomatch>
-			<match Class="PatchOperationAdd">
-				<xpath>/Defs/ThingDef[defName = "EndTable"]/comps</xpath>
-				<value>
-					<li Class="CompProperties_Styleable" />
-				</value>
-			</match>
-		</nomatch>
-	</Operation>
-
-
-
+	<!-- EndTable already inherits CompProperties_Styleable from its parent TableBase.
+	     Adding it again via XPath patch causes duplicate CompStyleable components,
+	     leading to duplicate sourcePrecept entries in save files and errors on load.
+	     The XPath conditional check doesn't detect inherited comps. -->
 
 </Patch>


### PR DESCRIPTION
## Summary
- Several `MakingFurnitureStyleable` patches (1.6) add `CompProperties_Styleable` to ThingDefs that **already inherit it** from abstract parents (`ResourceBase`, `TableBase`)
- The XPath conditional check (`comps/li[@Class="CompProperties_Styleable"]`) only inspects direct XML children and does **not** resolve RimWorld's XML inheritance (`ParentName`)
- This creates duplicate `CompStyleable` components, which write duplicate `<sourcePrecept>` entries on save, causing load errors: `Could not load reference to Verse.Precept named null`

## Affected defs (1.6)
| Patch file | ThingDefs | Inherits CompStyleable from |
|---|---|---|
| `ComponentsPatch.xml` | ComponentIndustrial, ComponentSpacer | ResourceBase |
| `EndTablePatch.xml` | EndTable | TableBase |

> **Note:** Only 1.6 patches are modified. The 1.5 inheritance chains were not verified and are left unchanged.

## Fix
Removed the redundant `PatchOperationConditional` blocks for these defs since they already have `CompStyleable` via their parent chain. The empty `<Patch>` elements are kept with comments explaining why.

## Test plan
- [x] Loaded modded save with bookcases, end tables, and components
- [x] Confirmed `sourcePrecept` duplicate errors no longer appear on load
- [x] Built new Bookcase, saved, reloaded — no errors